### PR TITLE
Dark mode fix - forcibly include the darkmode styles.

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Waryes</title>
   </head>
-  <body theme="dark">
+  <body>
     <main id="main">
 
     </main>

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,10 @@
 import { Router } from '@vaadin/router';
+import '@vaadin/vaadin-lumo-styles';
+import { color } from '@vaadin/vaadin-lumo-styles';
+
+const $tpl1 = document.createElement('template');
+$tpl1.innerHTML = `<style>${color.toString().replace(':host', 'html')}</style>`;
+document.head.appendChild($tpl1.content);
 
 const router = new Router(document.getElementById("main"));
 


### PR DESCRIPTION
I'm not sure if this is the "correct" solution, but this seems to work.  

Dark mode styles are located in `@vaadin/vaadin-lumo-styles`, specifically `@vaadin/vaadin-lumo-styles/colors.js`.  

Light mode colors are appended to the dom, but dark mode styles are not - they are set using `registerStyles('', color, { moduleId: 'lumo-color' });`.  An ideal solution probably figures out how to utilize the styles being registered there.

This solution instead just uses the same code they use to add the light styles, but for dark as well.  It manually creates the style block with the dark mode styles.
