### PR TITLE
feat: improve landing page unit search and improve ux of unit comparison input

### DIFF
--- a/src/services/units-db.ts
+++ b/src/services/units-db.ts
@@ -6,6 +6,9 @@ import { Unit } from "../types/unit";
 const CURRENT_FILE_NAME = 'unit-bundle-post-suchet.txt'
 const CURRENT_NAMED_QUERY = 'units-post-suchet'
 
+// Regex to remove a lot of punctuation found in unit names, helps search methods
+export const UNIT_SEARCH_IGNORED_CHARACTERS = /[.,-\/#!$%\^\*\(\)\[\]\{\}]/g
+
 enum UnitFetchStrategy {
     cache,
     forceDirect
@@ -78,7 +81,11 @@ class UnitsDatabaseServiceClass {
         const unitsQuery = await getDocsFromCache(query);
 
         this.units = unitsQuery.docs.map( function(doc) {
-            return doc.data() as Unit
+            let unitData = doc.data() as Unit;
+            return {
+                ...unitData,
+                _searchNameHelper: unitData.name.toLowerCase().replace(UNIT_SEARCH_IGNORED_CHARACTERS, "")
+            }
         });
 
         this._readCounter += this.units.length;

--- a/src/types/unit.ts
+++ b/src/types/unit.ts
@@ -64,8 +64,10 @@ interface Unit {
     ecm:                    number,
     agility?:               number, 
     travelTime?:            number,
-    weapons:                Weapon[]
-    
+    weapons:                Weapon[],
+
+    _searchNameHelper:      string,
+
     // TODO: Audit / remove
     // old values missing or removed
     // _name:              string,


### PR DESCRIPTION
This PR attempts to improve unit searching functionality on the main landing page as well as on the unit comparison page.

On all unit searches a custom filter method has been added to ignore punctuation in the unit names and in the search inputs.  This means you can search for f-16s with either "f16" or "f-16".   

On the multiselect combo box found on the unit comparison screen the custom filtering also comes with another additional benefit: selecting a unit will no longer clear the current search.  So you can enter "f16" and select all f16s without having to enter f16 every time.  Search terms are reset when the dropdown has been closed.  If you wanted to compare all f16s to all mig29s you type f16 once, click all the f16s, type mig29 once and select all the m29s and you're done.

Needs a second set of eyes before deployment.



