### PR TITLE
fix: inconsistent deck-builder flag sizes on small screens

### DIFF
--- a/src/routes/deck-builder.ts
+++ b/src/routes/deck-builder.ts
@@ -124,6 +124,11 @@ export class DeckBuilderRoute
         justify-content: center;
       }
 
+      button > span {
+        display: flex;
+        flex: 1 1 0%;
+      }
+
       country-flag {
         margin-right: var(--lumo-space-s);
       }


### PR DESCRIPTION
updated division name text to use flex and expand from a 0% basis to fix flag icon inconsistencies on smaller screens.