### PR TITLE
Issue #36 - Add trait descriptions on hover

### DIFF
--- a/src/components/deck/armoury-card-styles.ts
+++ b/src/components/deck/armoury-card-styles.ts
@@ -15,7 +15,6 @@ export const armouryCardStyles = css`
     flex: 1 1 100%;
 
     border-radius: var(--lumo-border-radius-m);
-    overflow: hidden;
 
     color: white;
   }

--- a/src/components/deck/armoury-card.ts
+++ b/src/components/deck/armoury-card.ts
@@ -11,7 +11,8 @@ import {DialogOpenedChangedEvent} from '@vaadin/dialog';
 import {dialogHeaderRenderer, dialogRenderer} from '@vaadin/dialog/lit.js';
 import '@vaadin/dialog';
 import '../unit-card';
-import {getIconForTrait} from '../../utils/get-icon-for-trait';
+import "./../unit-traits";
+
 export interface ArmouryCardOptions {
   unit: Unit;
   veterancyOptions?: ArmouryCardVeterancyOptions;
@@ -107,9 +108,7 @@ export class ArmouryCard extends LitElement {
 
     return html`<div class="main ${this.disabled ? 'disabled' : ''}">
       <div class="traits">
-        ${unit.specialities.length > 1
-          ? unit.specialities.slice(1).map((trait) => getIconForTrait(trait))
-          : 'No Traits'}
+        ${this.renderTraits(unit.specialities)}
       </div>
       <div class="body">
         <div class="top-section">
@@ -132,6 +131,13 @@ export class ArmouryCard extends LitElement {
         deck
       )}
     </div>`;
+  }
+
+  renderTraits(specialities: Array<string>) {
+    const specsThatAreTraits = specialities.filter(s => s[0] == '_');
+    return specsThatAreTraits.length > 0
+      ? html`<unit-traits .traitNames=${specialities.filter(s => s[0] == '_')}></unit-traits>`
+      : 'No Traits';
   }
 
   renderButton(activeVeterancy: number, unit: Unit, _pack: Pack, _deck: Deck) {

--- a/src/components/deck/armoury-card.ts
+++ b/src/components/deck/armoury-card.ts
@@ -12,6 +12,7 @@ import {dialogHeaderRenderer, dialogRenderer} from '@vaadin/dialog/lit.js';
 import '@vaadin/dialog';
 import '../unit-card';
 import "./../unit-traits";
+import { isSpecialtyTrait } from '../../utils/is-specialty-trait';
 
 export interface ArmouryCardOptions {
   unit: Unit;
@@ -134,9 +135,9 @@ export class ArmouryCard extends LitElement {
   }
 
   renderTraits(specialities: Array<string>) {
-    const specsThatAreTraits = specialities.filter(s => s[0] == '_');
+    const specsThatAreTraits = specialities.filter(s => isSpecialtyTrait(s));
     return specsThatAreTraits.length > 0
-      ? html`<unit-traits .traitNames=${specialities.filter(s => s[0] == '_')}></unit-traits>`
+      ? html`<unit-traits .traitNames=${specsThatAreTraits}></unit-traits>`
       : 'No Traits';
   }
 

--- a/src/components/deck/armoury-card.ts
+++ b/src/components/deck/armoury-card.ts
@@ -12,7 +12,7 @@ import {dialogHeaderRenderer, dialogRenderer} from '@vaadin/dialog/lit.js';
 import '@vaadin/dialog';
 import '../unit-card';
 import "./../unit-traits";
-import { isSpecialtyTrait } from '../../utils/is-specialty-trait';
+import {isSpecialtyTrait} from '../../utils/is-specialty-trait';
 
 export interface ArmouryCardOptions {
   unit: Unit;

--- a/src/components/deck/edit-deck.ts
+++ b/src/components/deck/edit-deck.ts
@@ -89,7 +89,7 @@ export class EditDeck extends LitElement {
         height: 60px;
         width: 100%;
         background-color: var(--lumo-base-color);
-        z-index: 1;
+        z-index: 2;
         display: flex;
         justify-content: space-between;
         align-items: center;

--- a/src/components/unit-card-header-view.ts
+++ b/src/components/unit-card-header-view.ts
@@ -8,9 +8,9 @@ import './mod-image';
 import '@vaadin/button';
 import './division-flag';
 import {Unit} from '../types/unit';
-import {getIconForTrait} from '../utils/get-icon-for-trait';
 import {getIconsWithFallback} from '../utils/get-icons-with-fallback';
 import {router} from '../services/router';
+import "./unit-traits";
 
 /**
  * Component for rendering the details of a single unit
@@ -98,53 +98,6 @@ export class UnitCardHeaderView extends LitElement {
         justify-content: flex-start;
         column-gap: var(--lumo-space-s);
       }
-
-      .trait-tooltip-toggle {
-        position: relative;
-
-        .trait-tooltip {
-          display: none;
-          position: absolute;
-          top: 30px;
-          background-color: #303236;
-          border-radius: 2px;
-          color: #fff;
-          padding: 10px;
-          text-transform: none;
-          width: 220px;
-          font-size: 11px;
-        }
-
-        .trait-tooltip div {
-          padding-top: 2px;
-          padding-bottom: 2px;
-        }
-
-        .trait-tooltip ul {
-          padding: 2px 0px 0px 25px;
-          margin: 0px;
-        }
-
-        .trait-tooltip div:first-child {
-          padding-top: 0px;
-        }
-
-        .trait-tooltip div:last-child {
-          padding-bottom: 0px;
-        }
-
-        .trait-tooltip-header {
-          display: flex;
-          justify-content: space-between;
-          align-items: baseline;
-          white-space: nowrap;
-        }
-
-        &:hover .trait-tooltip {
-          display: flex;
-          flex-direction: column;
-        }
-      }
     `;
   }
 
@@ -206,11 +159,7 @@ export class UnitCardHeaderView extends LitElement {
               : html``}
           </div>
           <div class="traits">
-            ${traits.map(
-              (speciality) => html`<div class="icon-container">
-                ${getIconForTrait(speciality)}
-              </div>`
-            )}
+            <unit-traits .traitNames=${traits.filter(s => s[0] == '_')}></unit-traits>
           </div>
         </div>
       `;

--- a/src/components/unit-card-header-view.ts
+++ b/src/components/unit-card-header-view.ts
@@ -188,7 +188,7 @@ export class UnitCardHeaderView extends LitElement {
                   theme="primary"
                   @click=${() =>
                     this.dispatchEvent(
-                      new CustomEvent('mode-toggled', { detail: !this.expert })
+                      new CustomEvent('mode-toggled', {detail: !this.expert})
                     )}
                   >${this.expert ? 'Simple' : 'Expert'}</vaadin-button
                 >`}

--- a/src/components/unit-card-header-view.ts
+++ b/src/components/unit-card-header-view.ts
@@ -1,5 +1,5 @@
-import { css, html, LitElement, TemplateResult } from 'lit';
-import { customElement, property } from 'lit/decorators.js';
+import {css, html, LitElement, TemplateResult} from 'lit';
+import {customElement, property} from 'lit/decorators.js';
 import './unit-armor-view';
 import './unit-weapon-view';
 import './unit-info-panel-view';
@@ -7,10 +7,10 @@ import './trait-badge';
 import './mod-image';
 import '@vaadin/button';
 import './division-flag';
-import { Unit } from '../types/unit';
-import { getIconForTrait } from '../utils/get-icon-for-trait';
-import { getIconsWithFallback } from '../utils/get-icons-with-fallback';
-import { router } from '../services/router';
+import {Unit} from '../types/unit';
+import {getIconForTrait} from '../utils/get-icon-for-trait';
+import {getIconsWithFallback} from '../utils/get-icons-with-fallback';
+import {router} from '../services/router';
 
 /**
  * Component for rendering the details of a single unit
@@ -175,21 +175,21 @@ export class UnitCardHeaderView extends LitElement {
           <div style="display: flex; gap: var(--lumo-space-xs);">
             <a
               href=${router.urlForPath('/damage-calculator/:unitId', {
-        unitId: this.unit.descriptorName,
-      })}
+                unitId: this.unit.descriptorName,
+              })}
               title="Damage Calculator"
             >
               <vaadin-icon icon="waryes:calculator"></vaadin-icon>
             </a>
 
             ${this.hideExpertButton
-          ? html``
-          : html` <vaadin-button
+              ? html``
+              : html` <vaadin-button
                   theme="primary"
                   @click=${() =>
-              this.dispatchEvent(
-                new CustomEvent('mode-toggled', { detail: !this.expert })
-              )}
+                    this.dispatchEvent(
+                      new CustomEvent('mode-toggled', { detail: !this.expert })
+                    )}
                   >${this.expert ? 'Simple' : 'Expert'}</vaadin-button
                 >`}
           </div>
@@ -202,15 +202,15 @@ export class UnitCardHeaderView extends LitElement {
           <div class="unit-category icon-container">
             <vaadin-icon icon=${icons.icon}></vaadin-icon>
             ${icons.subIcon
-          ? html`<vaadin-icon icon=${icons.subIcon}></vaadin-icon>`
-          : html``}
+              ? html`<vaadin-icon icon=${icons.subIcon}></vaadin-icon>`
+              : html``}
           </div>
           <div class="traits">
             ${traits.map(
-            (speciality) => html`<div class="icon-container">
+              (speciality) => html`<div class="icon-container">
                 ${getIconForTrait(speciality)}
               </div>`
-          )}
+            )}
           </div>
         </div>
       `;

--- a/src/components/unit-card-header-view.ts
+++ b/src/components/unit-card-header-view.ts
@@ -1,5 +1,5 @@
-import {css, html, LitElement, TemplateResult} from 'lit';
-import {customElement, property} from 'lit/decorators.js';
+import { css, html, LitElement, TemplateResult } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
 import './unit-armor-view';
 import './unit-weapon-view';
 import './unit-info-panel-view';
@@ -7,10 +7,10 @@ import './trait-badge';
 import './mod-image';
 import '@vaadin/button';
 import './division-flag';
-import {Unit} from '../types/unit';
-import {getIconForTrait} from '../utils/get-icon-for-trait';
-import {getIconsWithFallback} from '../utils/get-icons-with-fallback';
-import {router} from '../services/router';
+import { Unit } from '../types/unit';
+import { getIconForTrait } from '../utils/get-icon-for-trait';
+import { getIconsWithFallback } from '../utils/get-icons-with-fallback';
+import { router } from '../services/router';
 
 /**
  * Component for rendering the details of a single unit
@@ -98,6 +98,53 @@ export class UnitCardHeaderView extends LitElement {
         justify-content: flex-start;
         column-gap: var(--lumo-space-s);
       }
+
+      .trait-tooltip-toggle {
+        position: relative;
+
+        .trait-tooltip {
+          display: none;
+          position: absolute;
+          top: 30px;
+          background-color: #303236;
+          border-radius: 2px;
+          color: #fff;
+          padding: 10px;
+          text-transform: none;
+          width: 220px;
+          font-size: 11px;
+        }
+
+        .trait-tooltip div {
+          padding-top: 2px;
+          padding-bottom: 2px;
+        }
+
+        .trait-tooltip ul {
+          padding: 2px 0px 0px 25px;
+          margin: 0px;
+        }
+
+        .trait-tooltip div:first-child {
+          padding-top: 0px;
+        }
+
+        .trait-tooltip div:last-child {
+          padding-bottom: 0px;
+        }
+
+        .trait-tooltip-header {
+          display: flex;
+          justify-content: space-between;
+          align-items: baseline;
+          white-space: nowrap;
+        }
+
+        &:hover .trait-tooltip {
+          display: flex;
+          flex-direction: column;
+        }
+      }
     `;
   }
 
@@ -128,21 +175,21 @@ export class UnitCardHeaderView extends LitElement {
           <div style="display: flex; gap: var(--lumo-space-xs);">
             <a
               href=${router.urlForPath('/damage-calculator/:unitId', {
-                unitId: this.unit.descriptorName,
-              })}
+        unitId: this.unit.descriptorName,
+      })}
               title="Damage Calculator"
             >
               <vaadin-icon icon="waryes:calculator"></vaadin-icon>
             </a>
 
             ${this.hideExpertButton
-              ? html``
-              : html` <vaadin-button
+          ? html``
+          : html` <vaadin-button
                   theme="primary"
                   @click=${() =>
-                    this.dispatchEvent(
-                      new CustomEvent('mode-toggled', {detail: !this.expert})
-                    )}
+              this.dispatchEvent(
+                new CustomEvent('mode-toggled', { detail: !this.expert })
+              )}
                   >${this.expert ? 'Simple' : 'Expert'}</vaadin-button
                 >`}
           </div>
@@ -155,15 +202,15 @@ export class UnitCardHeaderView extends LitElement {
           <div class="unit-category icon-container">
             <vaadin-icon icon=${icons.icon}></vaadin-icon>
             ${icons.subIcon
-              ? html`<vaadin-icon icon=${icons.subIcon}></vaadin-icon>`
-              : html``}
+          ? html`<vaadin-icon icon=${icons.subIcon}></vaadin-icon>`
+          : html``}
           </div>
           <div class="traits">
             ${traits.map(
-              (speciality) => html`<div class="icon-container">
+            (speciality) => html`<div class="icon-container">
                 ${getIconForTrait(speciality)}
               </div>`
-            )}
+          )}
           </div>
         </div>
       `;

--- a/src/components/unit-card-header-view.ts
+++ b/src/components/unit-card-header-view.ts
@@ -11,6 +11,7 @@ import {Unit} from '../types/unit';
 import {getIconsWithFallback} from '../utils/get-icons-with-fallback';
 import {router} from '../services/router';
 import "./unit-traits";
+import {isSpecialtyTrait} from '../utils/is-specialty-trait';
 
 /**
  * Component for rendering the details of a single unit
@@ -159,7 +160,7 @@ export class UnitCardHeaderView extends LitElement {
               : html``}
           </div>
           <div class="traits">
-            <unit-traits .traitNames=${traits.filter(s => s[0] == '_')}></unit-traits>
+            <unit-traits .traitNames=${traits.filter(s => isSpecialtyTrait(s))}></unit-traits>
           </div>
         </div>
       `;

--- a/src/components/unit-traits.ts
+++ b/src/components/unit-traits.ts
@@ -1,0 +1,134 @@
+import {css, html, LitElement, TemplateResult} from 'lit';
+import {customElement, property} from 'lit/decorators.js';
+import {getTraitFromIconName} from '../utils/get-trait-from-icon-name';
+import "@vaadin/icon/src/vaadin-icon";
+import {getIconForSpecialty} from '../utils/get-icon-for-specialty';
+
+/**
+ * Component for rendering the traits of a unit
+ */
+@customElement('unit-traits')
+export class UnitTraits extends LitElement {
+  static get styles() {
+    return css`
+        .trait-tooltip-toggle {
+            position: relative;
+            z-index: 1;
+
+            .trait-tooltip {
+                visibility: hidden;
+                display: none;
+                position: absolute;
+                top: 30px;
+                background-color: #303236;
+                border-radius: 2px;
+                color: #fff;
+                padding: 10px;
+                text-transform: none;
+                width: 220px;
+                font-size: 11px;
+            }
+
+            .trait-tooltip div {
+                padding-top: 2px;
+                padding-bottom: 2px;
+            }
+
+            .trait-tooltip ul {
+                padding: 2px 0px 0px 25px;
+                margin: 0px;
+            }
+
+            .trait-tooltip div:first-child {
+                padding-top: 0px;
+            }
+
+            .trait-tooltip div:last-child {
+                padding-bottom: 0px;
+            }
+
+            .trait-tooltip-header {
+                display: flex;
+                justify-content: space-between;
+                align-items: baseline;
+                white-space: nowrap;
+            }
+
+            &:hover .trait-tooltip {
+                display: flex;
+                visibility: visible;
+                flex-direction: column;
+            }
+        }
+        .icon-container {
+            padding: var(--lumo-space-xs);
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            gap: var(--lumo-space-xs);
+        }
+
+        .icons {
+            display: flex;
+            padding-top: var(--lumo-space-xs);
+            padding-bottom: var(--lumo-space-xs);
+        }
+    `;
+  }
+
+  @property({ type: Array })
+    traitNames:Array<string> = [];
+
+
+  private _shiftTooltipOnViewportOverflow(event: MouseEvent) {
+    const tooltipToggler = event.currentTarget as HTMLElement;
+    const openedTooltip = tooltipToggler.querySelector<HTMLElement>('.trait-tooltip');
+
+    const rightBoundary = openedTooltip?.getBoundingClientRect().right ?? 0;
+    const tooltipWidth = 200; // width less padding
+    const shift = rightBoundary - window.innerWidth - 8; // less the padding on view route element
+
+    if (openedTooltip && shift > 0)
+        openedTooltip.style.right = `${(-tooltipWidth + shift)}px`;
+  }
+
+  private _resetShiftOnTooltipClose(event: MouseEvent) {
+    const tooltipToggler = event.currentTarget as HTMLElement;
+    const openedTooltip = tooltipToggler.querySelector<HTMLElement>('.trait-tooltip');
+    openedTooltip?.style.removeProperty('right');
+  }
+
+  render(): TemplateResult {
+    const traits = this.traitNames.map(n => getTraitFromIconName(getIconForSpecialty(n)));
+    return html`<div class="icon-container">
+        ${traits.map(t => (
+            html`<div class="trait-tooltip-toggle" @mouseover="${this._shiftTooltipOnViewportOverflow}" @mouseout="${this._resetShiftOnTooltipClose}">
+                <vaadin-icon
+                id="${t.name}"
+                icon="waryes:${t.icon}"
+                class="trait-tooltip-toggle"
+                ></vaadin-icon>
+            <div class="trait-tooltip">
+                <div class="trait-tooltip-header">
+                    <div class="trait-tooltip-name"><b>Trait: </b>${t.name}</div>
+                    <div class="trait-tooltip-range"><b>Range: </b>${t.range}</div>
+                </div>
+                <div class="trait-tooltip-activation"><b>Activation: </b>${t.activationCondition}</div>
+                <div class="trait-tooltip-effects">
+                    <b>Effects: </b>
+                    <ul>
+                        ${t.effects.map(e => html`<li>${e}</li>`)}
+                    </ul>
+                </div>
+            </div>
+        </div>`
+        ))}
+    </div>`
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'unit-traits': UnitTraits;
+  }
+}

--- a/src/components/unit-traits.ts
+++ b/src/components/unit-traits.ts
@@ -1,6 +1,6 @@
-import { css, html, LitElement, TemplateResult } from 'lit';
-import { customElement, property } from 'lit/decorators.js';
-import { getTraitFromIconName } from '../utils/get-trait-from-icon-name';
+import {css, html, LitElement, TemplateResult} from 'lit';
+import {customElement, property} from 'lit/decorators.js';
+import {getTraitFromIconName} from '../utils/get-trait-from-icon-name';
 import "@vaadin/icon/src/vaadin-icon";
 import {getIconForSpecialty} from '../utils/get-icon-for-specialty';
 
@@ -20,8 +20,8 @@ export class UnitTraits extends LitElement {
             position: absolute;
             top: 30px;
             background-color: var(--lumo-base-color);
-            border-radius: 2px;
-            color: white;
+            border-radius: var(--lumo-border-radius);
+            color: var(--lumo-body-text-color);
             padding: 10px;
             text-transform: none;
             width: 220px;

--- a/src/components/unit-traits.ts
+++ b/src/components/unit-traits.ts
@@ -102,29 +102,29 @@ export class UnitTraits extends LitElement {
   render(): TemplateResult {
     const traits = this.traitNames.map(n => getTraitFromIconName(getIconForSpecialty(n)));
     return html`<div class="icon-container">
-        ${traits.map(t => (
-      html`<div class="trait-tooltip-toggle" @mouseover="${this._shiftTooltipOnViewportOverflow}" @mouseout="${this._resetShiftOnTooltipClose}">
-        <vaadin-icon
-          id="${t.name}"
-          icon="waryes:${t.icon}"
-          class="trait-tooltip-toggle"
-          ></vaadin-icon>
-          <div class="trait-tooltip">
-            <div class="trait-tooltip-header">
-              <div class="trait-tooltip-name"><b>Trait: </b>${t.name}</div>
-              <div class="trait-tooltip-range"><b>Range: </b>${t.range}</div>
-            </div>
-              <div class="trait-tooltip-activation"><b>Activation: </b>${t.activationCondition}</div>
-              <div class="trait-tooltip-effects">
-                  <b>Effects: </b>
-                  <ul>
-                    ${t.effects.map(e => html`<li>${e}</li>`)}
-                  </ul>
+      ${traits.map(t => (
+        html`<div class="trait-tooltip-toggle" @mouseover="${this._shiftTooltipOnViewportOverflow}" @mouseout="${this._resetShiftOnTooltipClose}">
+          <vaadin-icon
+            id="${t.name}"
+            icon="waryes:${t.icon}"
+            class="trait-tooltip-toggle"
+            ></vaadin-icon>
+            <div class="trait-tooltip">
+              <div class="trait-tooltip-header">
+                <div class="trait-tooltip-name"><b>Trait: </b>${t.name}</div>
+                <div class="trait-tooltip-range"><b>Range: </b>${t.range}</div>
               </div>
-          </div>
-      </div>`
-    ))}
-  </div>`
+                <div class="trait-tooltip-activation"><b>Activation: </b>${t.activationCondition}</div>
+                <div class="trait-tooltip-effects">
+                  <b>Effects: </b>
+                    <ul>
+                      ${t.effects.map(e => html`<li>${e}</li>`)}
+                    </ul>
+                </div>
+            </div>
+        </div>`
+      ))}
+    </div>`
   }
 }
 

--- a/src/components/unit-traits.ts
+++ b/src/components/unit-traits.ts
@@ -13,7 +13,6 @@ export class UnitTraits extends LitElement {
     return css`
         .trait-tooltip-toggle {
             position: relative;
-            z-index: 1;
 
             .trait-tooltip {
                 visibility: hidden;
@@ -27,6 +26,7 @@ export class UnitTraits extends LitElement {
                 text-transform: none;
                 width: 220px;
                 font-size: 11px;
+                z-index: 1;
             }
 
             .trait-tooltip div {

--- a/src/components/unit-traits.ts
+++ b/src/components/unit-traits.ts
@@ -1,8 +1,8 @@
-import {css, html, LitElement, TemplateResult} from 'lit';
-import {customElement, property} from 'lit/decorators.js';
-import {getTraitFromIconName} from '../utils/get-trait-from-icon-name';
+import { css, html, LitElement, TemplateResult } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
+import { getTraitFromIconName } from '../utils/get-trait-from-icon-name';
 import "@vaadin/icon/src/vaadin-icon";
-import {getIconForSpecialty} from '../utils/get-icon-for-specialty';
+import { getIconForSpecialty } from '../utils/get-icon-for-specialty';
 
 /**
  * Component for rendering the traits of a unit
@@ -11,73 +11,74 @@ import {getIconForSpecialty} from '../utils/get-icon-for-specialty';
 export class UnitTraits extends LitElement {
   static get styles() {
     return css`
-        .trait-tooltip-toggle {
-            position: relative;
+      .trait-tooltip-toggle {
+        position: relative;
 
-            .trait-tooltip {
-                visibility: hidden;
-                display: none;
-                position: absolute;
-                top: 30px;
-                background-color: #303236;
-                border-radius: 2px;
-                color: #fff;
-                padding: 10px;
-                text-transform: none;
-                width: 220px;
-                font-size: 11px;
-                z-index: 1;
-            }
+          .trait-tooltip {
+            visibility: hidden;
+            display: none;
+            position: absolute;
+            top: 30px;
+            background-color: #303236;
+            border-radius: 2px;
+            color: #fff;
+            padding: 10px;
+            text-transform: none;
+            width: 220px;
+            font-size: 11px;
+            z-index: 1;
+          }
 
-            .trait-tooltip div {
-                padding-top: 2px;
-                padding-bottom: 2px;
-            }
+          .trait-tooltip div {
+            padding-top: 2px;
+            padding-bottom: 2px;
+          }
 
-            .trait-tooltip ul {
-                padding: 2px 0px 0px 25px;
-                margin: 0px;
-            }
+          .trait-tooltip ul {
+            padding: 2px 0px 0px 25px;
+            margin: 0px;
+          }
 
-            .trait-tooltip div:first-child {
-                padding-top: 0px;
-            }
+          .trait-tooltip div:first-child {
+            padding-top: 0px;
+          }
 
-            .trait-tooltip div:last-child {
-                padding-bottom: 0px;
-            }
+          .trait-tooltip div:last-child {
+            padding-bottom: 0px;
+          }
 
-            .trait-tooltip-header {
-                display: flex;
-                justify-content: space-between;
-                align-items: baseline;
-                white-space: nowrap;
-            }
-
-            &:hover .trait-tooltip {
-                display: flex;
-                visibility: visible;
-                flex-direction: column;
-            }
-        }
-        .icon-container {
-            padding: var(--lumo-space-xs);
+          .trait-tooltip-header {
             display: flex;
-            justify-content: center;
-            align-items: center;
-            gap: var(--lumo-space-xs);
+            justify-content: space-between;
+            align-items: baseline;
+            white-space: nowrap;
+          }
+
+          &:hover .trait-tooltip {
+            display: flex;
+            visibility: visible;
+            flex-direction: column;
+          }
+        }
+
+        .icon-container {
+          padding: var(--lumo-space-xs);
+          display: flex;
+          justify-content: center;
+          align-items: center;
+          gap: var(--lumo-space-xs);
         }
 
         .icons {
-            display: flex;
-            padding-top: var(--lumo-space-xs);
-            padding-bottom: var(--lumo-space-xs);
+          display: flex;
+          padding-top: var(--lumo-space-xs);
+          padding-bottom: var(--lumo-space-xs);
         }
     `;
   }
 
   @property({ type: Array })
-    traitNames:Array<string> = [];
+  traitNames: Array<string> = [];
 
 
   private _shiftTooltipOnViewportOverflow(event: MouseEvent) {
@@ -89,7 +90,7 @@ export class UnitTraits extends LitElement {
     const shift = rightBoundary - window.innerWidth - 8; // less the padding on view route element
 
     if (openedTooltip && shift > 0)
-        openedTooltip.style.right = `${(-tooltipWidth + shift)}px`;
+      openedTooltip.style.right = `${(-tooltipWidth + shift)}px`;
   }
 
   private _resetShiftOnTooltipClose(event: MouseEvent) {
@@ -102,28 +103,28 @@ export class UnitTraits extends LitElement {
     const traits = this.traitNames.map(n => getTraitFromIconName(getIconForSpecialty(n)));
     return html`<div class="icon-container">
         ${traits.map(t => (
-            html`<div class="trait-tooltip-toggle" @mouseover="${this._shiftTooltipOnViewportOverflow}" @mouseout="${this._resetShiftOnTooltipClose}">
-                <vaadin-icon
-                id="${t.name}"
-                icon="waryes:${t.icon}"
-                class="trait-tooltip-toggle"
-                ></vaadin-icon>
-            <div class="trait-tooltip">
-                <div class="trait-tooltip-header">
-                    <div class="trait-tooltip-name"><b>Trait: </b>${t.name}</div>
-                    <div class="trait-tooltip-range"><b>Range: </b>${t.range}</div>
-                </div>
-                <div class="trait-tooltip-activation"><b>Activation: </b>${t.activationCondition}</div>
-                <div class="trait-tooltip-effects">
-                    <b>Effects: </b>
-                    <ul>
-                        ${t.effects.map(e => html`<li>${e}</li>`)}
-                    </ul>
-                </div>
+      html`<div class="trait-tooltip-toggle" @mouseover="${this._shiftTooltipOnViewportOverflow}" @mouseout="${this._resetShiftOnTooltipClose}">
+        <vaadin-icon
+          id="${t.name}"
+          icon="waryes:${t.icon}"
+          class="trait-tooltip-toggle"
+          ></vaadin-icon>
+          <div class="trait-tooltip">
+            <div class="trait-tooltip-header">
+              <div class="trait-tooltip-name"><b>Trait: </b>${t.name}</div>
+              <div class="trait-tooltip-range"><b>Range: </b>${t.range}</div>
             </div>
-        </div>`
-        ))}
-    </div>`
+              <div class="trait-tooltip-activation"><b>Activation: </b>${t.activationCondition}</div>
+              <div class="trait-tooltip-effects">
+                  <b>Effects: </b>
+                  <ul>
+                    ${t.effects.map(e => html`<li>${e}</li>`)}
+                  </ul>
+              </div>
+          </div>
+      </div>`
+    ))}
+  </div>`
   }
 }
 

--- a/src/components/unit-traits.ts
+++ b/src/components/unit-traits.ts
@@ -2,7 +2,7 @@ import { css, html, LitElement, TemplateResult } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import { getTraitFromIconName } from '../utils/get-trait-from-icon-name';
 import "@vaadin/icon/src/vaadin-icon";
-import { getIconForSpecialty } from '../utils/get-icon-for-specialty';
+import {getIconForSpecialty} from '../utils/get-icon-for-specialty';
 
 /**
  * Component for rendering the traits of a unit
@@ -19,9 +19,9 @@ export class UnitTraits extends LitElement {
             display: none;
             position: absolute;
             top: 30px;
-            background-color: #303236;
+            background-color: var(--lumo-base-color);
             border-radius: 2px;
-            color: #fff;
+            color: white;
             padding: 10px;
             text-transform: none;
             width: 220px;

--- a/src/types/trait.ts
+++ b/src/types/trait.ts
@@ -1,5 +1,6 @@
 interface Trait {
     name: string;
+    icon: string;
     range: string; // 'N/A' if none
     activationCondition: string; // N/A if none
     effects: string[]

--- a/src/types/trait.ts
+++ b/src/types/trait.ts
@@ -2,6 +2,6 @@ interface Trait {
     name: string;
     icon: string;
     range: string; // 'N/A' if none
-    activationCondition: string; // N/A if none
+    activationCondition: string; // 'N/A' if none
     effects: string[]
 }

--- a/src/types/trait.ts
+++ b/src/types/trait.ts
@@ -1,0 +1,6 @@
+interface Trait {
+    name: string;
+    range: string; // 'N/A' if none
+    activationCondition: string; // N/A if none
+    effects: string[]
+}

--- a/src/utils/get-icon-for-trait.ts
+++ b/src/utils/get-icon-for-trait.ts
@@ -1,41 +1,33 @@
-import {TemplateResult, html} from 'lit';
+import { TemplateResult, html } from 'lit';
 import { getIconForSpecialty } from './get-icon-for-specialty';
+import { getTraitFromIconName } from './get-trait-from-icon-name';
 import '@vaadin/icon';
-
-
-function humanize(input: string): string {
-  const words = input.split('-');
-  // remove the first word if it is 'trait'
-  if (words[0] === 'trait') {
-    words.shift();
-  }
-
-
-  return words.map((word) => word.charAt(0).toUpperCase() + word.slice(1)).join(' ');
-}
 
 export function getIconForTrait(trait: string): TemplateResult {
   const elementId = `trait-${trait}`;
 
-  const speciality = getIconForSpecialty(trait);
+  const icon = getIconForSpecialty(trait);
+  const fullTrait = getTraitFromIconName(icon);
 
-  const icon = speciality;
-  let tooltip: string;
-  try {
-    tooltip = humanize(speciality);
-  }
-  catch(err) {
-    tooltip = speciality;
-  }
-
-
-  if (speciality === 'parachute') {
-    tooltip = "Airbourne"
-  }
-
-  return html` <vaadin-icon
+  return html` 
+  <div class="trait-tooltip-toggle">
+    <vaadin-icon
       id="${elementId}"
       icon="waryes:${icon}"
-    ></vaadin-icon
-    ><vaadin-tooltip for=${elementId} text=${tooltip} position="top"></vaadin-tooltip>`;
+      class="trait-tooltip-toggle"
+    ></vaadin-icon>
+    <div class="trait-tooltip">
+      <div class="trait-tooltip-header">
+        <div class="trait-tooltip-name"><b>Trait: </b>${fullTrait.name}</div>
+        <div class="trait-tooltip-range"><b>Range: </b>${fullTrait.range}</div>
+      </div>
+      <div class="trait-tooltip-activation"><b>Activation: </b>${fullTrait.activationCondition}</div>
+      <div class="trait-tooltip-effects">
+        <b>Effects: </b>
+        <ul>
+          ${fullTrait.effects.map(e => html`<li>${e}</li>`)}
+        </ul>
+      </div>
+    </div>
+  </div>`;
 }

--- a/src/utils/get-icon-for-trait.ts
+++ b/src/utils/get-icon-for-trait.ts
@@ -1,37 +1,15 @@
 import {TemplateResult, html} from 'lit';
-import { getIconForSpecialty } from './get-icon-for-specialty';
+import {getIconForSpecialty} from './get-icon-for-specialty';
 import '@vaadin/icon';
-
-
-function humanize(input: string): string {
-  const words = input.split('-');
-  // remove the first word if it is 'trait'
-  if (words[0] === 'trait') {
-    words.shift();
-  }
-
-
-  return words.map((word) => word.charAt(0).toUpperCase() + word.slice(1)).join(' ');
-}
+import {getTraitFromIconName} from './get-trait-from-icon-name';
+import "@vaadin/tooltip/src/vaadin-tooltip";
 
 export function getIconForTrait(trait: string): TemplateResult {
   const elementId = `trait-${trait}`;
-
   const speciality = getIconForSpecialty(trait);
-
   const icon = speciality;
-  let tooltip: string;
-  try {
-    tooltip = humanize(speciality);
-  }
-  catch(err) {
-    tooltip = speciality;
-  }
 
-
-  if (speciality === 'parachute') {
-    tooltip = "Airbourne"
-  }
+  const tooltip = getTraitFromIconName(speciality)?.name; // will be null if not a trait
 
   return html` <vaadin-icon
       id="${elementId}"

--- a/src/utils/get-icon-for-trait.ts
+++ b/src/utils/get-icon-for-trait.ts
@@ -1,6 +1,6 @@
-import { TemplateResult, html } from 'lit';
-import { getIconForSpecialty } from './get-icon-for-specialty';
-import { getTraitFromIconName } from './get-trait-from-icon-name';
+import {TemplateResult, html} from 'lit';
+import {getIconForSpecialty} from './get-icon-for-specialty';
+import {getTraitFromIconName} from './get-trait-from-icon-name';
 import '@vaadin/icon';
 
 export function getIconForTrait(trait: string): TemplateResult {

--- a/src/utils/get-icon-for-trait.ts
+++ b/src/utils/get-icon-for-trait.ts
@@ -1,33 +1,41 @@
 import {TemplateResult, html} from 'lit';
-import {getIconForSpecialty} from './get-icon-for-specialty';
-import {getTraitFromIconName} from './get-trait-from-icon-name';
+import { getIconForSpecialty } from './get-icon-for-specialty';
 import '@vaadin/icon';
+
+
+function humanize(input: string): string {
+  const words = input.split('-');
+  // remove the first word if it is 'trait'
+  if (words[0] === 'trait') {
+    words.shift();
+  }
+
+
+  return words.map((word) => word.charAt(0).toUpperCase() + word.slice(1)).join(' ');
+}
 
 export function getIconForTrait(trait: string): TemplateResult {
   const elementId = `trait-${trait}`;
 
-  const icon = getIconForSpecialty(trait);
-  const fullTrait = getTraitFromIconName(icon);
+  const speciality = getIconForSpecialty(trait);
 
-  return html` 
-  <div class="trait-tooltip-toggle">
-    <vaadin-icon
+  const icon = speciality;
+  let tooltip: string;
+  try {
+    tooltip = humanize(speciality);
+  }
+  catch(err) {
+    tooltip = speciality;
+  }
+
+
+  if (speciality === 'parachute') {
+    tooltip = "Airbourne"
+  }
+
+  return html` <vaadin-icon
       id="${elementId}"
       icon="waryes:${icon}"
-      class="trait-tooltip-toggle"
-    ></vaadin-icon>
-    <div class="trait-tooltip">
-      <div class="trait-tooltip-header">
-        <div class="trait-tooltip-name"><b>Trait: </b>${fullTrait.name}</div>
-        <div class="trait-tooltip-range"><b>Range: </b>${fullTrait.range}</div>
-      </div>
-      <div class="trait-tooltip-activation"><b>Activation: </b>${fullTrait.activationCondition}</div>
-      <div class="trait-tooltip-effects">
-        <b>Effects: </b>
-        <ul>
-          ${fullTrait.effects.map(e => html`<li>${e}</li>`)}
-        </ul>
-      </div>
-    </div>
-  </div>`;
+    ></vaadin-icon
+    ><vaadin-tooltip for=${elementId} text=${tooltip} position="top"></vaadin-tooltip>`;
 }

--- a/src/utils/get-trait-from-icon-name.ts
+++ b/src/utils/get-trait-from-icon-name.ts
@@ -17,9 +17,13 @@ const iconTraitMap: IconTraitMap = {
     },
     'trait-leader':
     { 
-        name: "Leader", range: '', 
+        name: "Leader", range: 'Variable', 
         activationCondition: 'Own units nearby', 
-        effects: ['Grants +1 veterancy to all allies within radius']
+        effects: [
+            'Grants +1 veterancy to all allies within radius',
+            'Radius is 425m/565m/636m depending on leader veterancy',
+            'Veterancy bonus caps at level 3 veterancy and does not apply to other leaders'
+        ]
     },
     'trait-ifv':
     { 

--- a/src/utils/get-trait-from-icon-name.ts
+++ b/src/utils/get-trait-from-icon-name.ts
@@ -1,0 +1,130 @@
+interface IconTraitMap {
+    [iconIdentifier: string]: Trait
+}
+
+const iconTraitMap: IconTraitMap = {
+    'trait-amphibious' : 
+    { 
+        name: "Amphibious", range: 'N/A', 
+        activationCondition: 'N/A', 
+        effects: ['Can traverse deep waters at 37.5% of the offroad speed']
+    },
+    'trait-recon':
+    { 
+        name: "Recon", range: 'N/A', 
+        activationCondition: 'N/A', 
+        effects: ['Deploys 2473m ahead at the start of the game']
+    },
+    'trait-leader':
+    { 
+        name: "Leader", range: '', 
+        activationCondition: 'Own units nearby', 
+        effects: ['Grants +1 veterancy to all allies within radius']
+    },
+    'trait-ifv':
+    { 
+        name: "IFV", range: '318m', 
+        activationCondition: 'Own infantry within range', 
+        effects: ['-50% suppression']
+    },
+    'trait-resolute':
+    { 
+        name: "Resolute", range: 'N/A', 
+        activationCondition: 'N/A', 
+        effects: ['-15% suppression']
+    },
+    'parachute':
+    { 
+        name: "Airborne", range: 'N/A', 
+        activationCondition: 'N/A', 
+        effects: ['Deploys 3534m ahead at the start of the game']
+    },
+    'trait-reservist':
+    { 
+        name: "Reservist", range: 'N/A', 
+        activationCondition: 'N/A', 
+        effects: [
+            '+33% suppression',
+            '+10% aimtime',
+            '-10% static & motion accuracy',
+            '+10% reload time'
+        ]
+    },
+    'trait-cqc':
+    { 
+        name: "Shock", range: '141m', 
+        activationCondition: 'Enemy units within range', 
+        effects: [
+            '-20% aim time',
+            '-20% reload time',
+            '-20% time between shots within a salvo',
+            '+20% damage inflicted'
+        ]
+    },
+    'trait-special-forces':
+    { 
+        name: "Special Forces", range: 'N/A', 
+        activationCondition: 'N/A', 
+        effects: ['Gains access to improved veterancy table']
+    },
+    'trait-mp':
+    { 
+        name: "Military Police", range: '265m', 
+        activationCondition: 'Own units within range', 
+        effects: [
+            '+1.25 suppression regeneration per second',
+            'removes reservist trait'
+        ]
+    },
+    'trait-gsr':
+    { 
+        name: "GSR", range: 'N/A', 
+        activationCondition: 'Immobile', 
+        effects: [
+            '+2000 vision',
+            '+43 optical strength'
+        ]
+    },
+    'trait-security':
+    { 
+        name: "Security", range: 'N/A', 
+        activationCondition: 'Immobile', 
+        effects: ['+43 optical strength']
+    },
+    'trait-transport':
+    { 
+        name: "Transport", range: 'N/A', 
+        activationCondition: 'N/A', 
+        effects: ['can transport owned infantry or towed weapons']
+    },
+    'trait-sniper':
+    { 
+        name: "Sniper", range: 'N/A', 
+        activationCondition: 'Immobile for 10 seconds', 
+        effects: [
+            '+0.5 dissimulation',
+            '+20% static accuracy',
+            '+500% damage inflicted'
+        ]
+    },
+    'trait-era':
+    { 
+        name: "ERA", range: 'N/A', 
+        activationCondition: 'N/A', 
+        effects: [
+            '+2 HP',
+            'up to +2 front/side armor',
+            '+1 damage taken from HEAT with tandem'
+        ]
+    },
+    'trait-false-flag':
+    { 
+        name: "False-Flag", range: 'N/A', 
+        activationCondition: 'N/A', 
+        effects: ['dangerousness is 0, will be last unit auto-targeted']
+    }
+}
+
+export function getTraitFromIconName(icon: string): Trait {
+    return iconTraitMap[icon];
+}

--- a/src/utils/get-trait-from-icon-name.ts
+++ b/src/utils/get-trait-from-icon-name.ts
@@ -5,18 +5,21 @@ interface IconTraitMap {
 const iconTraitMap: IconTraitMap = {
     'trait-amphibious' : 
     { 
+        icon: 'trait-amphibious',
         name: "Amphibious", range: 'N/A', 
         activationCondition: 'N/A', 
         effects: ['Can traverse deep waters at 37.5% of the offroad speed']
     },
     'trait-recon':
     { 
+        icon: 'trait-recon',
         name: "Recon", range: 'N/A', 
         activationCondition: 'N/A', 
         effects: ['Deploys 2473m ahead at the start of the game']
     },
     'trait-leader':
     { 
+        icon: 'trait-leader',
         name: "Leader", range: 'Variable', 
         activationCondition: 'Own units nearby', 
         effects: [
@@ -27,24 +30,28 @@ const iconTraitMap: IconTraitMap = {
     },
     'trait-ifv':
     { 
+        icon: 'trait-ifv',
         name: "IFV", range: '318m', 
         activationCondition: 'Own infantry within range', 
         effects: ['-50% suppression']
     },
     'trait-resolute':
     { 
+        icon: 'trait-resolute',
         name: "Resolute", range: 'N/A', 
         activationCondition: 'N/A', 
         effects: ['-15% suppression']
     },
     'parachute':
     { 
+        icon: 'parachute',
         name: "Airborne", range: 'N/A', 
         activationCondition: 'N/A', 
         effects: ['Deploys 3534m ahead at the start of the game']
     },
     'trait-reservist':
     { 
+        icon: 'trait-reservist',
         name: "Reservist", range: 'N/A', 
         activationCondition: 'N/A', 
         effects: [
@@ -56,6 +63,7 @@ const iconTraitMap: IconTraitMap = {
     },
     'trait-cqc':
     { 
+        icon: 'trait-cqc',
         name: "Shock", range: '141m', 
         activationCondition: 'Enemy units within range', 
         effects: [
@@ -67,12 +75,14 @@ const iconTraitMap: IconTraitMap = {
     },
     'trait-special-forces':
     { 
+        icon: 'trait-special-forces',
         name: "Special Forces", range: 'N/A', 
         activationCondition: 'N/A', 
         effects: ['Gains access to improved veterancy table']
     },
     'trait-mp':
     { 
+        icon: 'trait-mp',
         name: "Military Police", range: '265m', 
         activationCondition: 'Own units within range', 
         effects: [
@@ -82,6 +92,7 @@ const iconTraitMap: IconTraitMap = {
     },
     'trait-gsr':
     { 
+        icon: 'trait-gsr',
         name: "GSR", range: 'N/A', 
         activationCondition: 'Immobile', 
         effects: [
@@ -91,18 +102,21 @@ const iconTraitMap: IconTraitMap = {
     },
     'trait-security':
     { 
+        icon: 'trait-security',
         name: "Security", range: 'N/A', 
         activationCondition: 'Immobile', 
         effects: ['+43 optical strength']
     },
     'trait-transport':
     { 
+        icon: 'trait-transport',
         name: "Transport", range: 'N/A', 
         activationCondition: 'N/A', 
         effects: ['can transport owned infantry or towed weapons']
     },
     'trait-sniper':
     { 
+        icon: 'trait-sniper',
         name: "Sniper", range: 'N/A', 
         activationCondition: 'Immobile for 10 seconds', 
         effects: [
@@ -113,6 +127,7 @@ const iconTraitMap: IconTraitMap = {
     },
     'trait-era':
     { 
+        icon: 'trait-era',
         name: "ERA", range: 'N/A', 
         activationCondition: 'N/A', 
         effects: [
@@ -123,6 +138,7 @@ const iconTraitMap: IconTraitMap = {
     },
     'trait-false-flag':
     { 
+        icon: 'trait-false-flag',
         name: "False-Flag", range: 'N/A', 
         activationCondition: 'N/A', 
         effects: ['dangerousness is 0, will be last unit auto-targeted']

--- a/src/utils/is-specialty-trait.ts
+++ b/src/utils/is-specialty-trait.ts
@@ -1,0 +1,7 @@
+/**
+ * Determines if the speciality is a trait, e.g. returns true if speciality is _choc, false if AT
+ */
+export function isSpecialtyTrait(specialty: string): boolean {
+    // right now all traits begin with underscore
+    return specialty.length > 0 && specialty[0] == '_';
+}

--- a/styles/app.css
+++ b/styles/app.css
@@ -29,7 +29,7 @@ html[theme~='dark'] {
   --lumo-secondary-color-10pct: hsla(60, 98%, 66%, 0.13);
   --lumo-clickable-cursor: pointer;
 
-  
+
   --warno-exceptional: rgb(117, 255, 255);
   --warno-exceptional-40pct: rgba(117, 255, 255, 0.4);
   --warno-good: rgb(127, 255, 117);
@@ -40,7 +40,7 @@ html[theme~='dark'] {
   --warno-bad-40pct: rgba(255, 168, 69, 0.4);
   --warno-very-bad: #ff5454;
   --warno-very-bad-40pct: rgba(255, 84, 84, 0.4);
-  
+
 }
 
 vaadin-dialog-overlay::part(header) {
@@ -82,13 +82,13 @@ vaadin-combo-box-item {
   border-bottom: 1px dotted var(--lumo-contrast-30pct);
 }
 
-.unit-search-result > .unit-information {
+.unit-search-result>.unit-information {
   display: flex;
   align-items: center;
   margin-top: var(--lumo-space-s);
 }
 
-.unit-search-result > .unit-image-wrapper {
+.unit-search-result>.unit-image-wrapper {
   margin-right: var(--lumo-space-s);
 }
 

--- a/styles/app.css
+++ b/styles/app.css
@@ -29,6 +29,7 @@ html[theme~='dark'] {
   --lumo-secondary-color-10pct: hsla(60, 98%, 66%, 0.13);
   --lumo-clickable-cursor: pointer;
 
+  
   --warno-exceptional: rgb(117, 255, 255);
   --warno-exceptional-40pct: rgba(117, 255, 255, 0.4);
   --warno-good: rgb(127, 255, 117);
@@ -39,6 +40,7 @@ html[theme~='dark'] {
   --warno-bad-40pct: rgba(255, 168, 69, 0.4);
   --warno-very-bad: #ff5454;
   --warno-very-bad-40pct: rgba(255, 84, 84, 0.4);
+  
 }
 
 vaadin-dialog-overlay::part(header) {

--- a/styles/app.css
+++ b/styles/app.css
@@ -29,7 +29,6 @@ html[theme~='dark'] {
   --lumo-secondary-color-10pct: hsla(60, 98%, 66%, 0.13);
   --lumo-clickable-cursor: pointer;
 
-
   --warno-exceptional: rgb(117, 255, 255);
   --warno-exceptional-40pct: rgba(117, 255, 255, 0.4);
   --warno-good: rgb(127, 255, 117);
@@ -40,7 +39,6 @@ html[theme~='dark'] {
   --warno-bad-40pct: rgba(255, 168, 69, 0.4);
   --warno-very-bad: #ff5454;
   --warno-very-bad-40pct: rgba(255, 84, 84, 0.4);
-
 }
 
 vaadin-dialog-overlay::part(header) {
@@ -82,13 +80,13 @@ vaadin-combo-box-item {
   border-bottom: 1px dotted var(--lumo-contrast-30pct);
 }
 
-.unit-search-result>.unit-information {
+.unit-search-result > .unit-information {
   display: flex;
   align-items: center;
   margin-top: var(--lumo-space-s);
 }
 
-.unit-search-result>.unit-image-wrapper {
+.unit-search-result > .unit-image-wrapper {
   margin-right: var(--lumo-space-s);
 }
 


### PR DESCRIPTION
Resolves #36 

Work is ready for review and merge. Currently the full tooltip is implemented in the deck builder, unit card (including the modal on info button click), and unit comparison.

Full tooltip is replaced with just the name of the trait for patch-notes and deck draft. Let me know if you want this changed. It'll take some more messing around with the css/component because the container doesn't work with the formatting in those routes.

button drawer z-index was changed to support tooltip, and also because images were laying over it prior as well.
Unit card:
![chrome_Ub39kjgW0d](https://github.com/CptToucan/waryes/assets/50683381/a4b4937f-22a0-4bcc-b938-9a73f45cac13)

Deck builder (mobile to show overflow fix):
![1mhEuhoEXA](https://github.com/CptToucan/waryes/assets/50683381/d3d47656-c14e-4b89-aba6-50659c9188e1)

Patch notes:
![chrome_9OW4jFDBCr](https://github.com/CptToucan/waryes/assets/50683381/69e88f73-69be-4e46-b4dc-f82c84e6041e)

Deck draft:
![chrome_mJUZ4Vku8C](https://github.com/CptToucan/waryes/assets/50683381/3c5b0286-920a-44ee-ad30-5e4b023fd0e6)

Modal:
![chrome_VS8WqEdXp5](https://github.com/CptToucan/waryes/assets/50683381/860aec6d-53be-4787-bb30-07ef8a001862)

Compare:
![chrome_Zl7mzfA6ly](https://github.com/CptToucan/waryes/assets/50683381/a2fc7dd6-2bc1-4af4-b169-174d3725816f)

